### PR TITLE
add csrf for ajax requests

### DIFF
--- a/mbc2/handlers/ajax/calculate.py
+++ b/mbc2/handlers/ajax/calculate.py
@@ -47,7 +47,6 @@ class Response(marshmallow.Schema, MembersBase):
 
 
 async def handler(request: web.Request) -> web.Response:
-    # TODO: add csrf
     data = await request.json()
     members_dc: models.Members = Request().load(data)
 

--- a/mbc2/main.py
+++ b/mbc2/main.py
@@ -15,7 +15,12 @@ TEMPLATES_LOADER = jinja2.FileSystemLoader(TEMPLATES_DIR)
 
 async def create_app() -> web.Application:
     logging.basicConfig(level=logging.INFO)
-    app = web.Application(middlewares=[middlewares.catch_validation_error])
+    app = web.Application(
+        middlewares=[
+            middlewares.catch_validation_error,
+            middlewares.ajax_csrf_token,
+        ],
+    )
     aiohttp_jinja2.setup(app, enable_async=True, loader=TEMPLATES_LOADER)
     routes.setup_routes(app)
     return app

--- a/mbc2/templates/base.html
+++ b/mbc2/templates/base.html
@@ -22,5 +22,19 @@
 </div>
 <script src="https://cdn.jsdelivr.net/npm/popper.js@1.14.6/dist/umd/popper.min.js" integrity="sha384-wHAiFfRlMFy6i5SRaxvfOCifBUQy1xHdJ/yoi7FRNXMRBu5WHdZYu1hA6ZOblgut" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.2.1/dist/js/bootstrap.min.js" integrity="sha384-B0UglyR+jN6CkvvICOB2joaf5I4l3gm9GU6Hc1og6Ls7i6U/mkkaduKaBhlAXv9k" crossorigin="anonymous"></script>
+<script type="text/javascript">
+    function csrfSafeMethod(method) {
+        // these HTTP methods do not require CSRF protection
+        return (/^(GET|HEAD|OPTIONS)$/.test(method));
+    }
+
+    $.ajaxSetup({
+        beforeSend: function(xhr, settings) {
+            if (!csrfSafeMethod(settings.type) && !this.crossDomain) {
+                xhr.setRequestHeader("X-Mbc-Csrf-Token", 1);
+            }
+        }
+    });
+</script>
 </body>
 </html>

--- a/tests/test_handlers/test_ajax/test_calculate.py
+++ b/tests/test_handlers/test_ajax/test_calculate.py
@@ -15,48 +15,100 @@ def _create_member(
     return result
 
 
+def _create_members_response(members: typing.List) -> typing.Dict:
+    return {'members': members}
+
+
+def _create_pytest_param(
+    *,
+    test_id: str,
+    members: typing.List,
+    expected_code: http.HTTPStatus = http.HTTPStatus.OK,
+    expected_response: typing.Dict,
+) -> typing.Any:
+    return pytest.param(
+        members,
+        expected_code,
+        expected_response,
+        id=test_id,
+    )
+
+
 @pytest.mark.parametrize(
-    ('members', 'expected_response'),
+    ('members', 'expected_code', 'expected_response'),
     (
-        pytest.param(
-            [_create_member(paid=50), _create_member()],
-            [
-                _create_member(paid=50, need_to_pay=25),
-                _create_member(need_to_pay=-25),
-            ],
-            id='OK',
+        _create_pytest_param(
+            members=[_create_member(paid=50), _create_member()],
+            expected_response=_create_members_response(
+                [
+                    _create_member(paid=50, need_to_pay=25),
+                    _create_member(need_to_pay=-25),
+                ],
+            ),
+            test_id='OK',
         ),
-        pytest.param(
-            [_create_member()],
-            [_create_member(need_to_pay=0)],
-            id='one member',
+        _create_pytest_param(
+            members=[_create_member()],
+            expected_response=_create_members_response(
+                [_create_member(need_to_pay=0)],
+            ),
+            test_id='one member',
         ),
-        pytest.param(
-            [_create_member(), _create_member()],
-            [_create_member(need_to_pay=0), _create_member(need_to_pay=0)],
-            id='same values',
+        _create_pytest_param(
+            members=[_create_member(), _create_member()],
+            expected_response=_create_members_response(
+                [_create_member(need_to_pay=0), _create_member(need_to_pay=0)],
+            ),
+            test_id='same values',
         ),
-        pytest.param(
-            [
+        _create_pytest_param(
+            members=[
                 _create_member(paid=1),
                 _create_member(paid=3),
                 _create_member(paid=1),
             ],
-            [
-                _create_member(paid=1.0, need_to_pay=0.67),
-                _create_member(paid=3.0, need_to_pay=-1.33),
-                _create_member(paid=1.0, need_to_pay=0.67),
-            ],
-            id='rounding',
+            expected_response=_create_members_response(
+                [
+                    _create_member(paid=1.0, need_to_pay=0.67),
+                    _create_member(paid=3.0, need_to_pay=-1.33),
+                    _create_member(paid=1.0, need_to_pay=0.67),
+                ],
+            ),
+            test_id='rounding',
+        ),
+        _create_pytest_param(
+            members=[],
+            expected_code=http.HTTPStatus.BAD_REQUEST,
+            expected_response={
+                'code': 'VALIDATION_ERROR',
+                'message': 'members: required at least 1 member',
+            },
+            test_id='validation-error',
         ),
     ),
 )
-async def test_calculate(web_app_client, members, expected_response):
+async def test_calculate(
+    web_app_client,
+    members,
+    expected_code,
+    expected_response,
+):
     response = await web_app_client.post(
         '/party-calc/calculate',
         json={'members': members},
+        headers={'X-Mbc-Csrf-Token': '1'},
     )
     body = await response.json()
-    assert response.status == http.HTTPStatus.OK
+    assert response.status == expected_code
 
-    assert body['members'] == expected_response
+    assert body == expected_response
+
+
+async def test_calculate_no_csrf(web_app_client):
+    response = await web_app_client.post(
+        '/party-calc/calculate',
+        json={'members': [_create_member()]},
+    )
+    assert response.status == http.HTTPStatus.FORBIDDEN
+    body = await response.json()
+    assert body == {'code': 'CSRF_ERROR', 'message': 'csrf error'}


### PR DESCRIPTION
Based on https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#custom-request-headers
Added csrf checking for ajax request. All ajax request must set X-Mbc-Csrf-Token to pass checking